### PR TITLE
Prefix job name with namespace and set display name to be slash separated

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -47,6 +47,8 @@ import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL;
 import static io.fabric8.jenkins.openshiftsync.BuildRunPolicy.SERIAL_LATEST_ONLY;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.isJenkinsBuildConfig;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobDisplayName;
+import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.jenkinsJobName;
 import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.parseResourceVersion;
 import static java.net.HttpURLConnection.HTTP_GONE;
 
@@ -176,12 +178,14 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
       ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
         @Override
         public Void call() throws Exception {
-          String jobName = OpenShiftUtils.jenkinsJobName(buildConfig);
+          String jobName = jenkinsJobName(buildConfig);
           WorkflowJob job = BuildTrigger.getDscp().getJobFromBuildConfigUid(buildConfig.getMetadata().getUid());
           boolean newJob = job == null;
           if (newJob) {
             job = new WorkflowJob(Jenkins.getActiveInstance(), jobName);
           }
+
+          job.setDisplayName(jenkinsJobDisplayName(buildConfig));
 
           FlowDefinition flowFromBuildConfig = mapBuildConfigToFlow(buildConfig);
           if (flowFromBuildConfig == null) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -59,8 +59,8 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
   private final String namespace;
   private Watch buildConfigWatch;
 
-  public BuildConfigWatcher(String defaultNamespace) {
-    this.namespace = defaultNamespace;
+  public BuildConfigWatcher(String namespace) {
+    this.namespace = namespace;
   }
 
   public void start(final Callable<Void> completionCallback) {
@@ -176,7 +176,7 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
       ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
         @Override
         public Void call() throws Exception {
-          String jobName = OpenShiftUtils.jenkinsJobName(buildConfig, namespace);
+          String jobName = OpenShiftUtils.jenkinsJobName(buildConfig);
           WorkflowJob job = BuildTrigger.getDscp().getJobFromBuildConfigUid(buildConfig.getMetadata().getUid());
           boolean newJob = job == null;
           if (newJob) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildSyncRunListener.java
@@ -60,11 +60,10 @@ import static io.fabric8.jenkins.openshiftsync.OpenShiftUtils.getOpenShiftClient
  */
 @Extension
 public class BuildSyncRunListener extends RunListener<Run> {
-
   private static final Logger logger = Logger.getLogger(BuildSyncRunListener.class.getName());
 
   private long pollPeriodMs = 1000;
-  private String defaultNamespace;
+  private String namespace;
 
   private transient Set<Run> runsToPoll = new CopyOnWriteArraySet<>();
 
@@ -106,7 +105,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
   }
 
   private void init() {
-    defaultNamespace = OpenShiftUtils.getNamespaceOrUseDefault(defaultNamespace, getOpenShiftClient());
+    namespace = OpenShiftUtils.getNamespaceOrUseDefault(namespace, getOpenShiftClient());
   }
 
   @Override
@@ -200,7 +199,7 @@ public class BuildSyncRunListener extends RunListener<Run> {
       return;
     }
 
-    String rootUrl = OpenShiftUtils.getJenkinsURL(getOpenShiftClient(), defaultNamespace);
+    String rootUrl = OpenShiftUtils.getJenkinsURL(getOpenShiftClient(), namespace);
     String buildUrl = joinPaths(rootUrl, run.getUrl());
     String logsUrl = joinPaths(buildUrl, "/consoleText");
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -24,4 +24,5 @@ public class Constants {
   public static final String OPENSHIFT_ANNOTATIONS_JENKINS_STATUS_JSON = "openshift.io/jenkins-status-json";
 
   public static final String OPENSHIFT_LABELS_BUILD_CONFIG_NAME = "openshift.io/build-config.name";
+  public static final String OPENSHIFT_DEFAULT_NAMESPACE = "default";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -137,6 +137,29 @@ public class OpenShiftUtils {
   }
 
   /**
+   * Finds the Jenkins job display name for the given {@link BuildConfig}.
+   *
+   * @param bc the BuildConfig
+   * @return the jenkins job display name for the given BuildConfig
+   */
+  public static String jenkinsJobDisplayName(BuildConfig bc) {
+    String namespace = bc.getMetadata().getNamespace();
+    String name = bc.getMetadata().getName();
+    return jenkinsJobDisplayName(namespace, name);
+  }
+
+  /**
+   * Creates the Jenkins Job display name for the given buildConfigName
+   *
+   * @param namespace the namespace of the build
+   * @param buildConfigName the name of the {@link BuildConfig} in in the namespace
+   * @return the jenkins job display name for the given namespace and name
+   */
+  public static String jenkinsJobDisplayName(String namespace, String buildConfigName) {
+    return namespace + "/" + buildConfigName;
+  }
+
+  /**
    * Gets the current namespace running Jenkins inside or returns a reasonable default
    *
    * @param configuredNamespace the optional configured namespace

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -51,6 +51,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static io.fabric8.jenkins.openshiftsync.BuildPhases.CANCELLED;
+import static io.fabric8.jenkins.openshiftsync.Constants.OPENSHIFT_DEFAULT_NAMESPACE;
 
 /**
  */
@@ -113,31 +114,25 @@ public class OpenShiftUtils {
   }
 
   /**
-   * Finds the Jenkins job for the given {@link BuildConfig} and defaultNamespace
+   * Finds the Jenkins job name for the given {@link BuildConfig}.
    *
    * @param bc the BuildConfig
-   * @param defaultNamespace the default namespace which does not prefix job names with "$namespace-buildConfigName"
-   * @return the jenkins job name for the given BuildConfig and default namespace
+   * @return the jenkins job name for the given BuildConfig
    */
-  public static String jenkinsJobName(BuildConfig bc, String defaultNamespace) {
+  public static String jenkinsJobName(BuildConfig bc) {
     String namespace = bc.getMetadata().getNamespace();
     String name = bc.getMetadata().getName();
-    return jenkinsJobName(namespace, name, defaultNamespace);
+    return jenkinsJobName(namespace, name);
   }
 
   /**
-   * Creates the Jenkins Job name for the given buildConfigName in a namespace and the default namespace for jenkins
+   * Creates the Jenkins Job name for the given buildConfigName
    *
    * @param namespace the namespace of the build
    * @param buildConfigName the name of the {@link BuildConfig} in in the namespace
-   * @param defaultNamespace the default namespace that Jenkins is running inside, which
-   *                         by doesn't prefix itself in front of jenkins job names
-   * @return the jenkins job name for the given namespace and build config name and default namesapce
+   * @return the jenkins job name for the given namespace and name
    */
-  public static String jenkinsJobName(String namespace, String buildConfigName, String defaultNamespace) {
-    if (namespace == null || namespace.length() == 0 || namespace.equals(defaultNamespace)) {
-      return buildConfigName;
-    }
+  public static String jenkinsJobName(String namespace, String buildConfigName) {
     return namespace + "-" + buildConfigName;
   }
 
@@ -153,7 +148,7 @@ public class OpenShiftUtils {
     if (StringUtils.isBlank(namespace)) {
       namespace = client.getNamespace();
       if (StringUtils.isBlank(namespace)) {
-        namespace = "default";
+        namespace = OPENSHIFT_DEFAULT_NAMESPACE;
       }
     }
     return namespace;
@@ -257,12 +252,12 @@ public class OpenShiftUtils {
    *
    * @return the namespaced name for the BuildConfig
    * @param jobName the job to associate to a BuildConfig name
-   * @param defaultNamespace the default namespace that Jenkins is running inside
+   * @param namespace the default namespace that Jenkins is running inside
    */
-  public static NamespaceName buildConfigNameFromJenkinsJobName(String jobName, String defaultNamespace) {
+  public static NamespaceName buildConfigNameFromJenkinsJobName(String jobName, String namespace) {
     // TODO lets detect the namespace separator in the jobName for cases where a jenkins is used for
     // BuildConfigs in multiple namespaces?
-    return new NamespaceName(defaultNamespace, jobName);
+    return new NamespaceName(namespace, jobName);
   }
 
   public static long parseResourceVersion(HasMetadata obj) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/PipelineJobListener.java
@@ -39,21 +39,21 @@ public class PipelineJobListener extends ItemListener {
   private static final Logger logger = Logger.getLogger(PipelineJobListener.class.getName());
 
   private String server;
-  private String defaultNamespace;
+  private String namespace;
 
   public PipelineJobListener() {
     init();
   }
 
   @DataBoundConstructor
-  public PipelineJobListener(String server, String defaultNamespace) {
+  public PipelineJobListener(String server, String namespace) {
     this.server = server;
-    this.defaultNamespace = defaultNamespace;
+    this.namespace = namespace;
     init();
   }
 
   private void init() {
-    defaultNamespace = OpenShiftUtils.getNamespaceOrUseDefault(defaultNamespace, getOpenShiftClient());
+    namespace = OpenShiftUtils.getNamespaceOrUseDefault(namespace, getOpenShiftClient());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class PipelineJobListener extends ItemListener {
         && StringUtils.isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getNamespace())
         && StringUtils.isNotBlank(job.getProperty(BuildConfigProjectProperty.class).getName())) {
 
-        NamespaceName buildName = OpenShiftUtils.buildConfigNameFromJenkinsJobName(job.getName(), defaultNamespace);
+        NamespaceName buildName = OpenShiftUtils.buildConfigNameFromJenkinsJobName(job.getName(), namespace);
         logger.info("Deleting BuildConfig " + buildName);
 
         String namespace = buildName.getNamespace();


### PR DESCRIPTION
Job name will be <namespace>-<name> with job name more readable as <namespace>/<name>.

@bparees This is a bit of a change in job name and display but is pretty important for supporting multiple namespaces and in turn folders.