### PR TITLE
Pass Jenkins the revision information from the Openshift build

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JenkinsUtils.java
@@ -135,7 +135,6 @@ public class JenkinsUtils {
     SourceRevision sourceRevision = build.getSpec().getRevision();
 
     if (gitBuildSource != null && sourceRevision != null) {
-      sourceRevision = build.getSpec().getRevision();
       GitSourceRevision gitSourceRevision = sourceRevision.getGit();
       if (gitSourceRevision != null) {
         try {


### PR DESCRIPTION
When triggering a Jenkins build, when the OpenShift build contains revision information, pass that information to the Jenkins job as a RevisionParameterAction so that Jenkins will checkout the correct revision and if the Jenkinsfile is in the repository, will read the correct revision of the Jenkinsfile.