### PR TITLE
Remove excessive SEVERE logging when credentials not defined and update Jenkins Readiness Logic for watchers

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -18,22 +18,14 @@ package io.fabric8.jenkins.openshiftsync;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.model.Job;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersDefinitionProperty;
-import hudson.model.StringParameterDefinition;
-import hudson.model.StringParameterValue;
 import hudson.security.ACL;
 import hudson.triggers.SafeTimerTask;
 import hudson.util.XStream2;
-import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigList;
-import io.fabric8.openshift.api.model.JenkinsPipelineBuildStrategy;
-import io.fabric8.openshift.client.OpenShiftClient;
 import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
 import jenkins.util.Timer;
@@ -47,7 +39,6 @@ import javax.xml.transform.stream.StreamSource;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +83,10 @@ public class BuildConfigWatcher implements Watcher<BuildConfig> {
     Runnable task = new SafeTimerTask() {
       @Override
       public void doRun() {
+        if (!CredentialsUtils.hasCredentials()) {
+          logger.fine("No Openshift Token credential defined.");
+          return;
+        }
         for(String namespace:namespaces) {
           try {
             logger.fine("listing BuildConfigs resources");

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -71,6 +71,10 @@ public class BuildWatcher implements Watcher<Build> {
     Runnable task = new SafeTimerTask() {
       @Override
       public void doRun() {
+        if (!CredentialsUtils.hasCredentials()) {
+          logger.fine("No Openshift Token credential defined.");
+          return;
+        }
         for(String namespace:namespaces) {
           try {
             logger.fine("listing Build resources");

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -12,6 +12,7 @@ import io.fabric8.openshift.api.model.BuildConfig;
 import jenkins.model.Jenkins;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -168,4 +169,13 @@ public class CredentialsUtils {
       new String(Base64.decode(passwordData), StandardCharsets.UTF_8)
     );
   }
+
+  /**
+   * Does our configuration have credentials?
+   * @return true if found.
+   */
+  public static boolean hasCredentials() {
+    return !StringUtils.isEmpty(getAuthenticatedOpenShiftClient().getConfiguration().getOauthToken());
+  }
+
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -18,7 +18,7 @@ package io.fabric8.jenkins.openshiftsync;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.Computer;
+import hudson.init.InitMilestone;
 import hudson.security.ACL;
 import hudson.triggers.SafeTimerTask;
 import hudson.util.ListBoxModel;
@@ -161,19 +161,16 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
         protected void doRun() throws Exception {
           logger.info("Waiting for Jenkins to be started");
           while (true) {
-            Computer[] computers = Jenkins.getActiveInstance().getComputers();
-            boolean ready = false;
-            for (Computer c : computers) {
-              // Jenkins.isAcceptingTasks() results in hudson.model.Node.isAcceptingTasks() getting called, and that always returns true;
-              // the Computer.isAcceptingTasks actually introspects various Jenkins data structures to determine readiness
-              if (c.isAcceptingTasks()) {
-                ready = true;
-                break;
-              }
-            }
-            if (ready) {
+            final Jenkins instance = Jenkins.getActiveInstance();
+            // We can look at Jenkins Init Level to see if we are ready
+            // to start. If we do not wait, we risk the chance of a deadlock.
+            //
+            InitMilestone initLevel = instance.getInitLevel();
+            logger.fine("Jenkins init level: " + initLevel.toString());
+            if (initLevel == InitMilestone.COMPLETED) {
               break;
             }
+            logger.fine("Jenkins not ready...");
             try {
               Thread.sleep(500);
             } catch (InterruptedException e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -197,5 +197,4 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
       }
     }
   }
-
 }


### PR DESCRIPTION
- BuildWatcher and BuildConfigWatch both emit tons of
  log messages for failed authenticated requests which floods Jenkins logs.
  This will tame them.
- Remove some unused imports too.