### PR TITLE
Updated description of global config namespaces dialog

### DIFF
--- a/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
+++ b/src/main/resources/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration/config.jelly
@@ -30,7 +30,7 @@
       <c:select/>
     </f:entry>
     <f:entry title="Namespace" field="namespace"
-             description="The namespace to sync BuildConfigs with - leave blank to sync with all namespaces. Environment variables in the form ${name} will be expanded.  Multiple namespaces can be listed using a space separator.">
+             description="The namespace to sync BuildConfigs with. Environment variables in the form ${name} will be expanded.  Multiple namespaces can be listed using a space separator.">
       <f:textbox/>
     </f:entry>
   </f:section>


### PR DESCRIPTION
Removes text describing leaving namespace field blank to synchronize all namespaces. This functionality is not implemented and can be confusing for users