### PR TITLE
override user-agent to distinguish sync-plugin in openshift master lo…

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -83,6 +83,7 @@ public class BuildConfigWatcher extends BaseWatcher implements Watcher<BuildConf
                 onInitialBuildConfigs(buildConfigs);
                 logger.fine("handled BuildConfigs resources");
                 if (watches.get(namespace) == null) {
+                  logger.info("creating BuildConfig watch for namespace " + namespace + " and resource version " + buildConfigs.getMetadata().getResourceVersion());
                   watches.put(namespace,getAuthenticatedOpenShiftClient().buildConfigs().inNamespace(namespace).withResourceVersion(buildConfigs.getMetadata().getResourceVersion()).watch(BuildConfigWatcher.this));
                 }
               } catch (Exception e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -76,6 +76,7 @@ public class BuildWatcher extends BaseWatcher implements Watcher<Build> {
                 onInitialBuilds(newBuilds);
                 logger.fine("handled Build resources");
                 if (watches.get(namespace) == null) {
+                    logger.info("creating Build watch for namespace " + namespace + " and resource version " + newBuilds.getMetadata().getResourceVersion());
                   watches.put(namespace,getAuthenticatedOpenShiftClient().builds().inNamespace(namespace).withResourceVersion(newBuilds.getMetadata().getResourceVersion()).watch(BuildWatcher.this));
                 }
               } catch (Exception e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ConfigMapWatcher.java
@@ -66,6 +66,7 @@ public class ConfigMapWatcher extends BaseWatcher implements Watcher<ConfigMap> 
                         onInitialConfigMaps(configMaps);
                         logger.fine("handled ConfigMap resources");
                         if (watches.get(namespace) == null) {
+                            logger.info("creating ConfigMap watch for namespace " + namespace + " and resource version " + configMaps.getMetadata().getResourceVersion());
                             watches.put(namespace,getAuthenticatedOpenShiftClient().configMaps().inNamespace(namespace).withResourceVersion(configMaps.getMetadata().getResourceVersion()).watch(ConfigMapWatcher.this));
                         }
                     } catch (Exception e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/GlobalPluginConfiguration.java
@@ -153,6 +153,12 @@ public class GlobalPluginConfiguration extends GlobalConfiguration {
       if (buildWatcher != null) {
         buildWatcher.stop();
       }
+      if (configMapWatcher != null) {
+          configMapWatcher.stop();
+      }
+      if (imageStreamWatcher != null) {
+          imageStreamWatcher.stop();
+      }
       OpenShiftUtils.shutdownOpenShiftClient();
       return;
     }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/ImageStreamWatcher.java
@@ -64,6 +64,7 @@ public class ImageStreamWatcher extends BaseWatcher implements Watcher<ImageStre
                         onInitialImageStream(imageStreams);
                         logger.fine("handled ImageStream resources");
                         if (watches.get(namespace) == null) {
+                            logger.info("creating ImageStream watch for namespace " + namespace + " and resource version " + imageStreams.getMetadata().getResourceVersion());
                             watches.put(namespace,getAuthenticatedOpenShiftClient().imageStreams().inNamespace(namespace).withResourceVersion(imageStreams.getMetadata().getResourceVersion()).watch(ImageStreamWatcher.this));
                         }
                     } catch (Exception e) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.ReplicationControllerStatus;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.Version;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigSpec;
@@ -79,6 +80,7 @@ public class OpenShiftUtils {
       configBuilder.withMasterUrl(serverUrl);
     }
     Config config = configBuilder.build();
+    config.setUserAgent("openshift-sync-plugin/fabric8-" +Version.clientVersion());
     openShiftClient = new DefaultOpenShiftClient(config);
   }
 


### PR DESCRIPTION
…gs; close cfgmap/is watches on sync plugin disable

@bparees ptal - changes we've discussed stemming from recent us-east debug, plus a minor bug which sync plugin is disabled I found during code inspection 

I've ran the regression suite locally with success.

Current plan is to cherrypick this commit back into openshift/jenkins-sync-plugin after merge.  As openshift/jenkins-sync-plugin has some post 3.6 content, I've had to temporarily move from the rebase approach.  I'll re-sync the repos after 3.6 ships.