### PR TITLE
Keep existing Causes when pipeline build is manually triggered

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildDecisionHandler.java
@@ -63,9 +63,23 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
               .build()
           );
         
-        ParametersAction params = dumpParams(actions);        
+        ParametersAction params = dumpParams(actions);
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine("ParametersAction: " + params.toString());
+        }
         if (params != null && ret != null)
-            BuildToParametersActionMap.add(ret.getMetadata().getName(), params);
+            BuildToActionMapper.addParameterAction(ret.getMetadata().getName(), params);
+
+        CauseAction cause = dumpCause(actions);
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine("get CauseAction: " + cause.getDisplayName());
+            for (Cause c: cause.getCauses()) {
+                LOGGER.fine("Cause: " + c.getShortDescription());
+            }
+        }
+        if (cause != null && ret != null)
+            BuildToActionMapper.addCauseAction(ret.getMetadata().getName(), cause);
+
         return false;
       }
     }
@@ -86,6 +100,20 @@ public class BuildDecisionHandler extends Queue.QueueDecisionHandler {
       }
       return false;
     }
+
+  private static CauseAction dumpCause(List<Action> actions) {
+      for (Action action : actions) {
+          if (action instanceof CauseAction) {
+              CauseAction causeAction = (CauseAction) action;
+              if (LOGGER.isLoggable(Level.FINE))
+                  for (Cause cause : causeAction.getCauses()) {
+                      LOGGER.fine("cause: " + cause.getShortDescription());
+                  }
+              return causeAction;
+          }
+      }
+      return null;
+  }
 
   private static ParametersAction dumpParams(List<Action> actions) {
       for (Action action : actions) {

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToActionMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildToActionMapper.java
@@ -18,27 +18,40 @@ package io.fabric8.jenkins.openshiftsync;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import hudson.model.CauseAction;
 import hudson.model.ParametersAction;
 
-public class BuildToParametersActionMap {
+public class BuildToActionMapper {
     
     private static Map<String, ParametersAction> buildToParametersMap;
+    private static Map<String, CauseAction> buildToCauseMap;
 
-    private BuildToParametersActionMap() {
+    private BuildToActionMapper() {
     }
     
     static synchronized void initialize() {
         if (buildToParametersMap == null) {
             buildToParametersMap = new ConcurrentHashMap<String, ParametersAction>();
         }
+        if (buildToCauseMap == null) {
+            buildToCauseMap = new ConcurrentHashMap<String, CauseAction>();
+        }
     }
     
-    static synchronized void add(String buildId, ParametersAction params) {
+    static synchronized void addParameterAction(String buildId, ParametersAction params) {
         buildToParametersMap.put(buildId, params);
     }
     
-    static synchronized ParametersAction remove(String buildId) {
+    static synchronized ParametersAction removeParameterAction(String buildId) {
         return buildToParametersMap.remove(buildId);
+    }
+
+    static synchronized void addCauseAction(String buildId, CauseAction cause) {
+        buildToCauseMap.put(buildId, cause);
+    }
+
+    static synchronized CauseAction removeCauseAction(String buildId) {
+        return buildToCauseMap.remove(buildId);
     }
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildWatcher.java
@@ -89,7 +89,7 @@ public class BuildWatcher extends BaseWatcher implements Watcher<Build> {
   
 
   public void start() {
-    BuildToParametersActionMap.initialize();
+    BuildToActionMapper.initialize();
     super.start();
   }
 

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/OpenShiftUtils.java
@@ -241,6 +241,14 @@ public class OpenShiftUtils {
       logger.log(Level.WARNING, "Could not find Route for service " + namespace + "/" + serviceName + ". " + e, e);
     }
 
+    // let's try the Jenkins configured root url
+    // this can be needed if someone is not using 'jenkins'
+    // as the service name.
+    String rootUrl = Jenkins.getInstance().getRootUrl();
+    if (StringUtils.isNotEmpty(rootUrl)) {
+      return rootUrl;
+    }
+
     // lets default to the service DNS name
     return defaultProtocolText + serviceName;
   }


### PR DESCRIPTION
- Some plugins that provide triggering may rely on a Cause
  that they added to perform additional steps at a later time in the build.
  That Cause needs to be kept.
- An example of such a plugin is ghprb or Github Pull Request Builder.
  It looks at the Cause to extract information about the PR that triggered
  the build.
- Also included in this commit, is support for determining the Jenkins
  url in the event that someone created a Jenkins service that is not
  called 'jenkins'. Without this, the 'View Logs' from an Openshift
  pipeline build would not have the correct url.