### PR TITLE
username must be decoded

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -323,7 +323,8 @@ public class CredentialsUtils {
 
         }
         return new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, secretName,
-                fixNull(username),
+                fixNull(username).isEmpty() ? 
+                    "" : new String(Base64.decode(username), StandardCharsets.UTF_8),
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
                         new String(Base64.decode(sshKeyData),
                                 StandardCharsets.UTF_8)), null, secretName);


### PR DESCRIPTION
As in _newUsernamePasswordCredentials_ the username must be decoded.

![image](https://user-images.githubusercontent.com/1460734/40623713-8f346b7c-62a8-11e8-9a64-349d9ab08395.png)
