### PR TITLE
Proof of concept for SSH passphrases

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Constants.java
@@ -43,6 +43,7 @@ public class Constants {
     public static final String OPENSHIFT_SECRETS_DATA_USERNAME = "username";
     public static final String OPENSHIFT_SECRETS_DATA_PASSWORD = "password";
     public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY = "ssh-privatekey";
+    public static final String OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY_PASSPHRASE = "ssh-privatekey-passphrase";
     public static final String OPENSHIFT_SECRETS_DATA_FILENAME = "filename";
     public static final String OPENSHIFT_SECRETS_DATA_CERTIFICATE = "certificate";
     public static final String OPENSHIFT_SECRETS_DATA_SECRET_TEXT = "secrettext";

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -243,7 +243,7 @@ public class CredentialsUtils {
             }
             String sshKeyData = data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY);
             if (isNotBlank(sshKeyData)) {
-                return newSSHUserCredential(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME), sshKeyData);
+                return newSSHUserCredential(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME), sshKeyData, data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY_PASSPHRASE));
             }
             String fileData = data.get(OPENSHIFT_SECRETS_DATA_FILENAME);
             if (isNotBlank(fileData)) {
@@ -269,7 +269,7 @@ public class CredentialsUtils {
                     data.get(OPENSHIFT_SECRETS_DATA_PASSWORD));
         case OPENSHIFT_SECRETS_TYPE_SSH:
             return newSSHUserCredential(secretName, data.get(OPENSHIFT_SECRETS_DATA_USERNAME),
-                    data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY));
+                    data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY), data.get(OPENSHIFT_SECRETS_DATA_SSHPRIVATEKEY_PASSPHRASE));
         default:
             // the type field is marked optional in k8s.io/api/core/v1/types.go,
             // default to OPENSHIFT_SECRETS_DATA_SECRET_TEXT in this case
@@ -329,7 +329,7 @@ public class CredentialsUtils {
                 new CertificateCredentialsImpl.UploadedKeyStoreSource(SecretBytes.fromString(certificateData)));
     }
 
-    private static Credentials newSSHUserCredential(String secretName, String username, String sshKeyData) {
+    private static Credentials newSSHUserCredential(String secretName, String username, String sshKeyData, String passphrase) {
         if (secretName == null || secretName.length() == 0 || sshKeyData == null || sshKeyData.length() == 0) {
             logger.log(Level.WARNING,
                     "Invalid secret data, secretName: " + secretName + " sshKeyData is null: " + (sshKeyData == null)
@@ -341,7 +341,7 @@ public class CredentialsUtils {
                 fixNull(username).isEmpty() ? "" : new String(Base64.decode(username), StandardCharsets.UTF_8),
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
                         new String(Base64.decode(sshKeyData), StandardCharsets.UTF_8)),
-                null, secretName);
+                passphrase, secretName);
     }
 
     private static Credentials newUsernamePasswordCredentials(String secretName, String usernameData,

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -341,7 +341,7 @@ public class CredentialsUtils {
                 fixNull(username).isEmpty() ? "" : new String(Base64.decode(username), StandardCharsets.UTF_8),
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
                         new String(Base64.decode(sshKeyData), StandardCharsets.UTF_8)),
-                passphrase, secretName);
+                new String(Base64.decode(passphrase), StandardCharsets.UTF_8), secretName);
     }
 
     private static Credentials newUsernamePasswordCredentials(String secretName, String usernameData,


### PR DESCRIPTION
We'd like to be able to use SSH passphrases for authentication to Git, but the current sync plugin does not support them. These changes may be a good start. 
I was using this in my template:

`objects:
- apiVersion: v1
  stringData:
    ssh-privatekey: ${GIT_DEPLOY_KEY}
    ssh-privatekey-passphrase: ${GIT_DEPLOY_KEY_PASSPHRASE}
  kind: Secret
  metadata:
    annotations:
      build.openshift.io/source-secret-match-uri-1: 'ssh://github.com/foo/*'
    name: github-secret
  type: kubernetes.io/ssh-auth`

I don't know if the kubernetes.io/ssh-auth secret type is being misused for something it doesn't support yet. I could have just used an opaque secret though. Also, the UI doesn't allow you to create a source secret of ssh type with a passphrase.