### PR TITLE
allow autostart for build configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The synchronization works like this
 
 * Changes to OpenShift BuildConfig resources for Jenkins pipeline builds result in updates to the Jenkins Job of the same name; any BuildConfig source secrets are converted into Jenkins Credentials and registered with
 the Jenkins Credentials Plugin.
+    * Jobs created from BuildConfigs with annotation "jenkins.openshift.io/autostart='true'" are automatically triggered after the job is created in Jenkins. 
 * Creating a new OpenShift Build for a BuildConfig associated with a Jenkins Job results in the Jenkins Job being triggered
 * Changes in a Jenkins Build Run thats associated with a Jenkins Job gets replicated to an OpenShift Build object (which is created if necessary if the build was triggered via Jenkins)
 * Changes in OpenShift ConfigMap resources are examined for XML documents that correspond to Pod Template configuration for the Kubernetes Cloud plugin at http://github.com/jenkinsci/kubernetes-plugin and change the configuration of the Kubernetes Cloud plugin running in Jenkins to add, edit, or remove Pod Templates based on what exists in the ConfigMap; also note, if the <image></image> setting of the Pod Template starts with "imagestreamtag:", then this plugin will look up the ImageStreamTag for that entry (stripping "imagestreamtag:" first) and if found, replace the entry with the ImageStreamTag's Docker image reference.

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/Annotations.java
@@ -24,4 +24,5 @@ public class Annotations {
     public static final String DISABLE_SYNC_CREATE = "jenkins.openshift.io/disable-sync-create";
     public static final String BUILDCONFIG_NAME = "openshift.io/build-config.name";
     public static final String SECRET_NAME = "jenkins.openshift.io/secret.name";
+    public static final String AUTOSTART = "jenkins.openshift.io/autostart";
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/JobProcessor.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/JobProcessor.java
@@ -1,7 +1,7 @@
 package io.fabric8.jenkins.openshiftsync;
 
 
-import static io.fabric8.jenkins.openshiftsync.Annotations.DISABLE_SYNC_CREATE;
+import static io.fabric8.jenkins.openshiftsync.Annotations.*;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.getJobFromBuildConfig;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMap.putJobWithBuildConfig;
 import static io.fabric8.jenkins.openshiftsync.BuildConfigToJobMapper.mapBuildConfigToFlow;
@@ -137,8 +137,15 @@ public class JobProcessor extends NotReallyRoleSensitiveCallable<Void, Exception
 					activeInstance.createProjectFromXML(jobName, jobStream).save();
 				}
 
-				logger.info("Created job " + jobName + " from BuildConfig " + NamespaceName.create(buildConfig)
-						+ " with revision: " + buildConfig.getMetadata().getResourceVersion());
+				String autostart = getAnnotation(buildConfig, AUTOSTART);
+				if (Boolean.parseBoolean(autostart)) {
+					logger.info("Created and automatically starting job " + jobName + " from BuildConfig " 
+					        + NamespaceName.create(buildConfig)	+ " with revision: " + buildConfig.getMetadata().getResourceVersion());
+					job.scheduleBuild2(0);
+				} else {
+					logger.info("Created job " + jobName + " from BuildConfig " + NamespaceName.create(buildConfig)
+							+ " with revision: " + buildConfig.getMetadata().getResourceVersion());
+				}
 			} catch (IllegalArgumentException e) {
 				// see
 				// https://github.com/openshift/jenkins-sync-plugin/issues/117,
@@ -183,6 +190,4 @@ public class JobProcessor extends NotReallyRoleSensitiveCallable<Void, Exception
 		}
 		return existingBuildRunPolicy;
 	}
-
 }
-


### PR DESCRIPTION
This PullRequest allows to have jenkins pipeline jobs automatically started, when they are created by this plugin.

The use case of this feature is, when a jenkins job needs to run a first time to correctly initialize its triggers. e.g. Cron trigger, https://plugins.jenkins.io/generic-webhook-trigger/, ...

If this job never runs, it's trigger config gets never applied, hence it can not be started automatically.
This could now be achieved by adding the following annotation to the BuildConfig.

`
    jenkins.openshift.io/autostart: "true"
`