### PR TITLE
Jenkins 65712/secret name annotation fix

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/CredentialsUtils.java
@@ -34,7 +34,6 @@ import java.util.logging.Logger;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
-import org.codehaus.groovy.tools.StringHelper;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 


### PR DESCRIPTION
The logic regarding updating the secrets while using the annotation "jenkins.openshift.io/secret.name" has been rewritten to be more concise and readable, and actually works now. Tested on multiple Jenkins instances.

Jira issue: [JENKINS-65712](https://issues.jenkins.io/browse/JENKINS-65712)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
